### PR TITLE
デプロイ先の環境変数設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # IDE
-.vscode
+.vscode/settings.json
 
 # dependencies
 node_modules
@@ -17,10 +17,8 @@ build
 # misc
 .DS_Store
 .env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env.development
+.env.production
 
 npm-debug.log*
 yarn-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 [https://trancore.github.io/](https://trancore.github.io/)
+
+- dev環境の設定ファイル`.env.development`には、`REACT_APP_GITHUB_ACCESS_TOKEN_KEY={Github access token}`を追記して下さい
+
+- pro環境の設定ファイル`.env.production`には、`REACT_APP_GITHUB_ACCESS_TOKEN_KEY`の値は記載しないでください

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 [https://trancore.github.io/](https://trancore.github.io/)
 
 - dev環境の設定ファイル`.env.development`には、`REACT_APP_GITHUB_ACCESS_TOKEN_KEY={Github access token}`を追記して下さい
-
-- pro環境の設定ファイル`.env.production`には、`REACT_APP_GITHUB_ACCESS_TOKEN_KEY`の値は記載しないでください

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-[https://trancore.github.io/](https://trancore.github.io/)
+[https://trancore-github-io.vercel.app/](https://trancore-github-io.vercel.app/)
 
 - dev環境の設定ファイル`.env.development`には、`REACT_APP_GITHUB_ACCESS_TOKEN_KEY={Github access token}`を追記して下さい

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "prettier": "prettier --write 'src/**/*.{ts,tsx,scss}'",
     "precommit": "lint-staged",
     "predeploy": "yarn run build",
-    "deploy": "gh-pages -d build",
     "codegen": "graphql-codegen --config codegen.ts"
   },
   "dependencies": {
@@ -52,7 +51,6 @@
     "eslint": "^8.46.0",
     "eslint-config-prettier": "^8.9.0",
     "eslint-plugin-react": "^7.33.0",
-    "gh-pages": "^5.0.0",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.3",
     "postcss-scss": "^4.0.7",


### PR DESCRIPTION
## 目的もしくは関連する課題

<!-- このP-Rの目的を記載してください -->

- 現状で使っていた`gh-pages`ライブラリでは、ローカルでビルドしたものをgh-pagesブランチにプッシュしているため、ローカルで指定した環境変数がビルドした成果物に入ってしまっていた。
- Github Pagesでは環境変数を組み込めないため、ホスティング先をVercelに変更した。

- closes #25 

## 概要

<!-- このP-Rの概要を記載してください -->

- READMEのホスティングURL先を修正
- gh-pagesライブラリの削除

## 共有項目

<!-- このP-Rで共有した項目を記載してください -->

- 特に無し